### PR TITLE
More comprehensive stats from elasticsearch

### DIFF
--- a/bin/metrics-es-cluster.rb
+++ b/bin/metrics-es-cluster.rb
@@ -198,6 +198,10 @@ class ESClusterMetrics < Sensu::Plugin::Metric::CLI::Graphite
       flatten_metrics('indices', metrics, cluster_metrics['indices'])
       flatten_metrics('nodes.count', metrics, cluster_metrics['nodes']['count'])
       flatten_metrics('nodes.fs', metrics, cluster_metrics['nodes']['fs'])
+
+      metrics.each do |k, v|
+        output([config[:scheme], k].join('.'), v, timestamp)
+      end
     end
     ok
   end

--- a/bin/metrics-es-cluster.rb
+++ b/bin/metrics-es-cluster.rb
@@ -115,7 +115,7 @@ class ESClusterMetrics < Sensu::Plugin::Metric::CLI::Graphite
   end
 
   def acquire_health
-    health = get_es_resource('/_cluster/health').reject { |k, _v| %w(cluster_name timed_out).include?(k) }
+    health = get_es_resource('/_cluster/health').reject { |k, _v| %w(cluster_name timed_out number_of_nodes number_of_data_nodes active_shards active_primary_shards).include?(k) }
     health['status'] = %w(red yellow green).index(health['status'])
     health
   end

--- a/bin/metrics-es-node.rb
+++ b/bin/metrics-es-node.rb
@@ -85,6 +85,20 @@ class ESMetrics < Sensu::Plugin::Metric::CLI::Graphite
     warning 'Connection timed out'
   end
 
+  def flatten_metrics(prefix, dest_metrics, src_metrics)
+    src_metrics.each do |k, v|
+      if v.is_a? Numeric and k != 'timestamp'
+        dest_metrics[prefix + '.' + k] = v
+      end
+
+      if v.is_a? Hash
+        flatten_metrics(prefix + '.' + k, dest_metrics, v)
+      end
+    end
+
+    return dest_metrics
+  end
+
   def run
     es_version = Gem::Version.new(acquire_es_version)
 
@@ -100,16 +114,36 @@ class ESMetrics < Sensu::Plugin::Metric::CLI::Graphite
     node = stats['nodes'].values.first
     node['jvm']['mem']['heap_max_in_bytes'] = ln['nodes'].values.first['jvm']['mem']['heap_max_in_bytes']
     metrics = {}
+
+    # OS metrics
     metrics['os.load_average'] = if es_version >= Gem::Version.new('2.0.0')
                                    node['os']['load_average']
                                  else
                                    node['os']['load_average'][0]
                                  end
-    metrics['os.mem.free_in_bytes'] = node['os']['mem']['free_in_bytes']
-    metrics['process.mem.resident_in_bytes'] = node['process']['mem']['resident_in_bytes']
-    metrics['jvm.mem.heap_used_in_bytes'] = node['jvm']['mem']['heap_used_in_bytes']
-    metrics['jvm.mem.non_heap_used_in_bytes'] = node['jvm']['mem']['non_heap_used_in_bytes']
-    metrics['jvm.gc.collection_time_in_millis'] = node['jvm']['gc']['collection_time_in_millis']
+
+    flatten_metrics('os.mem', metrics, node['os']['mem'])
+
+    # Process metrics
+    flatten_metrics('process', metrics, node['process'])
+
+    # JVM metrics
+    flatten_metrics('jvm', metrics, node['jvm'])
+
+    # Threadpool metrics
+    flatten_metrics('threadpool', metrics, node['jvm'])
+
+    # Filesystem.
+    flatten_metrics('fs', metrics, node['fs']['total'])
+
+    flatten_metrics('transport', metrics, node['transport'])
+    flatten_metrics('http', metrics, node['http'])
+    flatten_metrics('indices', metrics, node['indices'])
+    flatten_metrics('breakers', metrics, node['breakers'])
+
+
+
+
     metrics.each do |k, v|
       output([config[:scheme], k].join('.'), v, timestamp)
     end

--- a/bin/metrics-es-node.rb
+++ b/bin/metrics-es-node.rb
@@ -141,9 +141,6 @@ class ESMetrics < Sensu::Plugin::Metric::CLI::Graphite
     flatten_metrics('indices', metrics, node['indices'])
     flatten_metrics('breakers', metrics, node['breakers'])
 
-
-
-
     metrics.each do |k, v|
       output([config[:scheme], k].join('.'), v, timestamp)
     end


### PR DESCRIPTION
An example of the stats that are returned now:

```
lee@cdb-101-4:~$ /opt/sensu/embedded/bin/ruby ~/metrics-es-node-updated.rb -s icebrg.elasticsearch.node
icebrg.elasticsearch.node.os.load_average 8.31 1457648370
icebrg.elasticsearch.node.os.mem.total_in_bytes 67442331648 1457648370
icebrg.elasticsearch.node.os.mem.free_in_bytes 282529792 1457648370
icebrg.elasticsearch.node.os.mem.used_in_bytes 67159801856 1457648370
icebrg.elasticsearch.node.os.mem.free_percent 0 1457648370
icebrg.elasticsearch.node.os.mem.used_percent 100 1457648370
icebrg.elasticsearch.node.process.open_file_descriptors 3669 1457648370
icebrg.elasticsearch.node.process.max_file_descriptors 65535 1457648370
icebrg.elasticsearch.node.process.cpu.percent 21 1457648370
icebrg.elasticsearch.node.process.cpu.total_in_millis 1446329530 1457648370
icebrg.elasticsearch.node.process.mem.total_virtual_in_bytes 828121313280 1457648370
icebrg.elasticsearch.node.jvm.uptime_in_millis 686266655 1457648370
icebrg.elasticsearch.node.jvm.mem.heap_used_in_bytes 26681120008 1457648370
icebrg.elasticsearch.node.jvm.mem.heap_used_percent 78 1457648370
icebrg.elasticsearch.node.jvm.mem.heap_committed_in_bytes 34200616960 1457648370
icebrg.elasticsearch.node.jvm.mem.heap_max_in_bytes 34200616960 1457648370
icebrg.elasticsearch.node.jvm.mem.non_heap_used_in_bytes 125754944 1457648370
icebrg.elasticsearch.node.jvm.mem.non_heap_committed_in_bytes 129282048 1457648370
icebrg.elasticsearch.node.jvm.mem.pools.young.used_in_bytes 1227141736 1457648370
icebrg.elasticsearch.node.jvm.mem.pools.young.max_in_bytes 1256259584 1457648370
icebrg.elasticsearch.node.jvm.mem.pools.young.peak_used_in_bytes 1256259584 1457648370
icebrg.elasticsearch.node.jvm.mem.pools.young.peak_max_in_bytes 1256259584 1457648370
icebrg.elasticsearch.node.jvm.mem.pools.survivor.used_in_bytes 142220936 1457648370
icebrg.elasticsearch.node.jvm.mem.pools.survivor.max_in_bytes 157024256 1457648370
icebrg.elasticsearch.node.jvm.mem.pools.survivor.peak_used_in_bytes 157024256 1457648370
icebrg.elasticsearch.node.jvm.mem.pools.survivor.peak_max_in_bytes 157024256 1457648370
icebrg.elasticsearch.node.jvm.mem.pools.old.used_in_bytes 25311757336 1457648370
icebrg.elasticsearch.node.jvm.mem.pools.old.max_in_bytes 32787333120 1457648370
icebrg.elasticsearch.node.jvm.mem.pools.old.peak_used_in_bytes 31851140344 1457648370
icebrg.elasticsearch.node.jvm.mem.pools.old.peak_max_in_bytes 32787333120 1457648370
icebrg.elasticsearch.node.jvm.threads.count 246 1457648370
icebrg.elasticsearch.node.jvm.threads.peak_count 259 1457648370
icebrg.elasticsearch.node.jvm.gc.collectors.young.collection_count 144862 1457648370
icebrg.elasticsearch.node.jvm.gc.collectors.young.collection_time_in_millis 9050003 1457648370
icebrg.elasticsearch.node.jvm.gc.collectors.old.collection_count 7770 1457648370
icebrg.elasticsearch.node.jvm.gc.collectors.old.collection_time_in_millis 896462 1457648370
icebrg.elasticsearch.node.jvm.buffer_pools.direct.count 16379 1457648370
icebrg.elasticsearch.node.jvm.buffer_pools.direct.used_in_bytes 396203511 1457648370
icebrg.elasticsearch.node.jvm.buffer_pools.direct.total_capacity_in_bytes 396203511 1457648370
icebrg.elasticsearch.node.jvm.buffer_pools.mapped.count 1195 1457648370
icebrg.elasticsearch.node.jvm.buffer_pools.mapped.used_in_bytes 778439160483 1457648370
icebrg.elasticsearch.node.jvm.buffer_pools.mapped.total_capacity_in_bytes 778439160483 1457648370
icebrg.elasticsearch.node.jvm.classes.current_loaded_count 8824 1457648370
icebrg.elasticsearch.node.jvm.classes.total_loaded_count 8920 1457648370
icebrg.elasticsearch.node.jvm.classes.total_unloaded_count 96 1457648370
icebrg.elasticsearch.node.threadpool.uptime_in_millis 686266655 1457648370
icebrg.elasticsearch.node.threadpool.mem.heap_used_in_bytes 26681120008 1457648370
icebrg.elasticsearch.node.threadpool.mem.heap_used_percent 78 1457648370
icebrg.elasticsearch.node.threadpool.mem.heap_committed_in_bytes 34200616960 1457648370
icebrg.elasticsearch.node.threadpool.mem.heap_max_in_bytes 34200616960 1457648370
icebrg.elasticsearch.node.threadpool.mem.non_heap_used_in_bytes 125754944 1457648370
icebrg.elasticsearch.node.threadpool.mem.non_heap_committed_in_bytes 129282048 1457648370
icebrg.elasticsearch.node.threadpool.mem.pools.young.used_in_bytes 1227141736 1457648370
icebrg.elasticsearch.node.threadpool.mem.pools.young.max_in_bytes 1256259584 1457648370
icebrg.elasticsearch.node.threadpool.mem.pools.young.peak_used_in_bytes 1256259584 1457648370
icebrg.elasticsearch.node.threadpool.mem.pools.young.peak_max_in_bytes 1256259584 1457648370
icebrg.elasticsearch.node.threadpool.mem.pools.survivor.used_in_bytes 142220936 1457648370
icebrg.elasticsearch.node.threadpool.mem.pools.survivor.max_in_bytes 157024256 1457648370
icebrg.elasticsearch.node.threadpool.mem.pools.survivor.peak_used_in_bytes 157024256 1457648370
icebrg.elasticsearch.node.threadpool.mem.pools.survivor.peak_max_in_bytes 157024256 1457648370
icebrg.elasticsearch.node.threadpool.mem.pools.old.used_in_bytes 25311757336 1457648370
icebrg.elasticsearch.node.threadpool.mem.pools.old.max_in_bytes 32787333120 1457648370
icebrg.elasticsearch.node.threadpool.mem.pools.old.peak_used_in_bytes 31851140344 1457648370
icebrg.elasticsearch.node.threadpool.mem.pools.old.peak_max_in_bytes 32787333120 1457648370
icebrg.elasticsearch.node.threadpool.threads.count 246 1457648370
icebrg.elasticsearch.node.threadpool.threads.peak_count 259 1457648370
icebrg.elasticsearch.node.threadpool.gc.collectors.young.collection_count 144862 1457648370
icebrg.elasticsearch.node.threadpool.gc.collectors.young.collection_time_in_millis 9050003 1457648370
icebrg.elasticsearch.node.threadpool.gc.collectors.old.collection_count 7770 1457648370
icebrg.elasticsearch.node.threadpool.gc.collectors.old.collection_time_in_millis 896462 1457648370
icebrg.elasticsearch.node.threadpool.buffer_pools.direct.count 16379 1457648370
icebrg.elasticsearch.node.threadpool.buffer_pools.direct.used_in_bytes 396203511 1457648370
icebrg.elasticsearch.node.threadpool.buffer_pools.direct.total_capacity_in_bytes 396203511 1457648370
icebrg.elasticsearch.node.threadpool.buffer_pools.mapped.count 1195 1457648370
icebrg.elasticsearch.node.threadpool.buffer_pools.mapped.used_in_bytes 778439160483 1457648370
icebrg.elasticsearch.node.threadpool.buffer_pools.mapped.total_capacity_in_bytes 778439160483 1457648370
icebrg.elasticsearch.node.threadpool.classes.current_loaded_count 8824 1457648370
icebrg.elasticsearch.node.threadpool.classes.total_loaded_count 8920 1457648370
icebrg.elasticsearch.node.threadpool.classes.total_unloaded_count 96 1457648370
icebrg.elasticsearch.node.fs.total_in_bytes 7938440990720 1457648370
icebrg.elasticsearch.node.fs.free_in_bytes 3105363611648 1457648370
icebrg.elasticsearch.node.fs.available_in_bytes 2705265807360 1457648370
icebrg.elasticsearch.node.transport.server_open 689 1457648370
icebrg.elasticsearch.node.transport.rx_count 36776974 1457648370
icebrg.elasticsearch.node.transport.rx_size_in_bytes 945761585003 1457648370
icebrg.elasticsearch.node.transport.tx_count 36663039 1457648370
icebrg.elasticsearch.node.transport.tx_size_in_bytes 1046044627139 1457648370
icebrg.elasticsearch.node.http.current_open 13 1457648370
icebrg.elasticsearch.node.http.total_opened 48795 1457648370
icebrg.elasticsearch.node.indices.docs.count 9496673113 1457648370
icebrg.elasticsearch.node.indices.docs.deleted 20918 1457648370
icebrg.elasticsearch.node.indices.store.size_in_bytes 4807708922262 1457648370
icebrg.elasticsearch.node.indices.store.throttle_time_in_millis 0 1457648370
icebrg.elasticsearch.node.indices.indexing.index_total 2985251261 1457648370
icebrg.elasticsearch.node.indices.indexing.index_time_in_millis 735727498 1457648370
icebrg.elasticsearch.node.indices.indexing.index_current 3 1457648370
icebrg.elasticsearch.node.indices.indexing.index_failed 10 1457648370
icebrg.elasticsearch.node.indices.indexing.delete_total 0 1457648370
icebrg.elasticsearch.node.indices.indexing.delete_time_in_millis 0 1457648370
icebrg.elasticsearch.node.indices.indexing.delete_current 0 1457648370
icebrg.elasticsearch.node.indices.indexing.noop_update_total 0 1457648370
icebrg.elasticsearch.node.indices.indexing.throttle_time_in_millis 0 1457648370
icebrg.elasticsearch.node.indices.get.total 0 1457648370
icebrg.elasticsearch.node.indices.get.time_in_millis 0 1457648370
icebrg.elasticsearch.node.indices.get.exists_total 0 1457648370
icebrg.elasticsearch.node.indices.get.exists_time_in_millis 0 1457648370
icebrg.elasticsearch.node.indices.get.missing_total 0 1457648370
icebrg.elasticsearch.node.indices.get.missing_time_in_millis 0 1457648370
icebrg.elasticsearch.node.indices.get.current 0 1457648370
icebrg.elasticsearch.node.indices.search.open_contexts 0 1457648370
icebrg.elasticsearch.node.indices.search.query_total 3936518 1457648370
icebrg.elasticsearch.node.indices.search.query_time_in_millis 71348948 1457648370
icebrg.elasticsearch.node.indices.search.query_current 0 1457648370
icebrg.elasticsearch.node.indices.search.fetch_total 600 1457648370
icebrg.elasticsearch.node.indices.search.fetch_time_in_millis 16249 1457648370
icebrg.elasticsearch.node.indices.search.fetch_current 0 1457648370
icebrg.elasticsearch.node.indices.search.scroll_total 0 1457648370
icebrg.elasticsearch.node.indices.search.scroll_time_in_millis 0 1457648370
icebrg.elasticsearch.node.indices.search.scroll_current 0 1457648370
icebrg.elasticsearch.node.indices.merges.current 3 1457648370
icebrg.elasticsearch.node.indices.merges.current_docs 14735460 1457648370
icebrg.elasticsearch.node.indices.merges.current_size_in_bytes 7845926006 1457648370
icebrg.elasticsearch.node.indices.merges.total 100707 1457648370
icebrg.elasticsearch.node.indices.merges.total_time_in_millis 920155720 1457648370
icebrg.elasticsearch.node.indices.merges.total_docs 11414668702 1457648370
icebrg.elasticsearch.node.indices.merges.total_size_in_bytes 5146717045574 1457648370
icebrg.elasticsearch.node.indices.merges.total_stopped_time_in_millis 43862 1457648370
icebrg.elasticsearch.node.indices.merges.total_throttled_time_in_millis 554360337 1457648370
icebrg.elasticsearch.node.indices.merges.total_auto_throttle_in_bytes 727601140 1457648370
icebrg.elasticsearch.node.indices.refresh.total 350182 1457648370
icebrg.elasticsearch.node.indices.refresh.total_time_in_millis 40217698 1457648370
icebrg.elasticsearch.node.indices.flush.total 2831 1457648370
icebrg.elasticsearch.node.indices.flush.total_time_in_millis 3403795 1457648370
icebrg.elasticsearch.node.indices.warmer.current 0 1457648370
icebrg.elasticsearch.node.indices.warmer.total 799283 1457648370
icebrg.elasticsearch.node.indices.warmer.total_time_in_millis 144236 1457648370
icebrg.elasticsearch.node.indices.query_cache.memory_size_in_bytes 579114880 1457648370
icebrg.elasticsearch.node.indices.query_cache.total_count 18171148 1457648370
icebrg.elasticsearch.node.indices.query_cache.hit_count 403452 1457648370
icebrg.elasticsearch.node.indices.query_cache.miss_count 17767696 1457648370
icebrg.elasticsearch.node.indices.query_cache.cache_size 41474 1457648370
icebrg.elasticsearch.node.indices.query_cache.cache_count 41546 1457648370
icebrg.elasticsearch.node.indices.query_cache.evictions 72 1457648370
icebrg.elasticsearch.node.indices.fielddata.memory_size_in_bytes 865077496 1457648370
icebrg.elasticsearch.node.indices.fielddata.evictions 0 1457648370
icebrg.elasticsearch.node.indices.percolate.total 0 1457648370
icebrg.elasticsearch.node.indices.percolate.time_in_millis 0 1457648370
icebrg.elasticsearch.node.indices.percolate.current 0 1457648370
icebrg.elasticsearch.node.indices.percolate.memory_size_in_bytes -1 1457648370
icebrg.elasticsearch.node.indices.percolate.queries 0 1457648370
icebrg.elasticsearch.node.indices.completion.size_in_bytes 0 1457648370
icebrg.elasticsearch.node.indices.segments.count 1686 1457648370
icebrg.elasticsearch.node.indices.segments.memory_in_bytes 20703723909 1457648370
icebrg.elasticsearch.node.indices.segments.terms_memory_in_bytes 13429555529 1457648370
icebrg.elasticsearch.node.indices.segments.stored_fields_memory_in_bytes 1040367368 1457648370
icebrg.elasticsearch.node.indices.segments.term_vectors_memory_in_bytes 0 1457648370
icebrg.elasticsearch.node.indices.segments.norms_memory_in_bytes 107776 1457648370
icebrg.elasticsearch.node.indices.segments.doc_values_memory_in_bytes 6233693236 1457648370
icebrg.elasticsearch.node.indices.segments.index_writer_memory_in_bytes 9722612 1457648370
icebrg.elasticsearch.node.indices.segments.index_writer_max_memory_in_bytes 550694912 1457648370
icebrg.elasticsearch.node.indices.segments.version_map_memory_in_bytes 2458002 1457648370
icebrg.elasticsearch.node.indices.segments.fixed_bit_set_memory_in_bytes 0 1457648370
icebrg.elasticsearch.node.indices.translog.operations 549971 1457648370
icebrg.elasticsearch.node.indices.translog.size_in_bytes 278998109 1457648370
icebrg.elasticsearch.node.indices.suggest.total 0 1457648370
icebrg.elasticsearch.node.indices.suggest.time_in_millis 0 1457648370
icebrg.elasticsearch.node.indices.suggest.current 0 1457648370
icebrg.elasticsearch.node.indices.request_cache.memory_size_in_bytes 0 1457648370
icebrg.elasticsearch.node.indices.request_cache.evictions 0 1457648370
icebrg.elasticsearch.node.indices.request_cache.hit_count 0 1457648370
icebrg.elasticsearch.node.indices.request_cache.miss_count 0 1457648370
icebrg.elasticsearch.node.indices.recovery.current_as_source 0 1457648370
icebrg.elasticsearch.node.indices.recovery.current_as_target 0 1457648370
icebrg.elasticsearch.node.indices.recovery.throttle_time_in_millis 57017897 1457648370
icebrg.elasticsearch.node.breakers.request.limit_size_in_bytes 13680246784 1457648370
icebrg.elasticsearch.node.breakers.request.estimated_size_in_bytes 0 1457648370
icebrg.elasticsearch.node.breakers.request.overhead 1.0 1457648370
icebrg.elasticsearch.node.breakers.request.tripped 0 1457648370
icebrg.elasticsearch.node.breakers.fielddata.limit_size_in_bytes 20520370176 1457648370
icebrg.elasticsearch.node.breakers.fielddata.estimated_size_in_bytes 865077496 1457648370
icebrg.elasticsearch.node.breakers.fielddata.overhead 1.03 1457648370
icebrg.elasticsearch.node.breakers.fielddata.tripped 0 1457648370
icebrg.elasticsearch.node.breakers.parent.limit_size_in_bytes 23940431872 1457648370
icebrg.elasticsearch.node.breakers.parent.estimated_size_in_bytes 865077496 1457648370
icebrg.elasticsearch.node.breakers.parent.overhead 1.0 1457648370
icebrg.elasticsearch.node.breakers.parent.tripped 0 1457648370

lee@cdb-101-4:~$ /opt/sensu/embedded/bin/ruby ~/metrics-es-cluster-updated.rb -s icebrg.elasticsearch.cluster
icebrg.elasticsearch.cluster.status 2 1457980502
icebrg.elasticsearch.cluster.relocating_shards 0 1457980502
icebrg.elasticsearch.cluster.initializing_shards 0 1457980502
icebrg.elasticsearch.cluster.unassigned_shards 0 1457980502
icebrg.elasticsearch.cluster.delayed_unassigned_shards 0 1457980502
icebrg.elasticsearch.cluster.number_of_pending_tasks 0 1457980502
icebrg.elasticsearch.cluster.number_of_in_flight_fetch 0 1457980502
icebrg.elasticsearch.cluster.task_max_waiting_in_queue_millis 0 1457980502
icebrg.elasticsearch.cluster.active_shards_percent_as_number 100.0 1457980502
icebrg.elasticsearch.cluster.allocation_status 3 1457980502
icebrg.elasticsearch.cluster.indices.count 44 1457980502
icebrg.elasticsearch.cluster.indices.shards.total 336 1457980502
icebrg.elasticsearch.cluster.indices.shards.primaries 168 1457980502
icebrg.elasticsearch.cluster.indices.shards.replication 1.0 1457980502
icebrg.elasticsearch.cluster.indices.shards.index.shards.min 2 1457980502
icebrg.elasticsearch.cluster.indices.shards.index.shards.max 10 1457980502
icebrg.elasticsearch.cluster.indices.shards.index.shards.avg 7.636363636363637 1457980502
icebrg.elasticsearch.cluster.indices.shards.index.primaries.min 1 1457980502
icebrg.elasticsearch.cluster.indices.shards.index.primaries.max 5 1457980502
icebrg.elasticsearch.cluster.indices.shards.index.primaries.avg 3.8181818181818183 1457980502
icebrg.elasticsearch.cluster.indices.shards.index.replication.min 1.0 1457980502
icebrg.elasticsearch.cluster.indices.shards.index.replication.max 1.0 1457980502
icebrg.elasticsearch.cluster.indices.shards.index.replication.avg 1.0 1457980502
icebrg.elasticsearch.cluster.indices.docs.count 54720584763 1457980502
icebrg.elasticsearch.cluster.indices.docs.deleted 183353 1457980502
icebrg.elasticsearch.cluster.indices.store.size_in_bytes 54650700275751 1457980502
icebrg.elasticsearch.cluster.indices.store.throttle_time_in_millis 0 1457980502
icebrg.elasticsearch.cluster.indices.fielddata.memory_size_in_bytes 17634430120 1457980502
icebrg.elasticsearch.cluster.indices.fielddata.evictions 0 1457980502
icebrg.elasticsearch.cluster.indices.query_cache.memory_size_in_bytes 899879520 1457980502
icebrg.elasticsearch.cluster.indices.query_cache.total_count 3088621123 1457980502
icebrg.elasticsearch.cluster.indices.query_cache.hit_count 267839701 1457980502
icebrg.elasticsearch.cluster.indices.query_cache.miss_count 2820781422 1457980502
icebrg.elasticsearch.cluster.indices.query_cache.cache_size 783824 1457980502
icebrg.elasticsearch.cluster.indices.query_cache.cache_count 7498157 1457980502
icebrg.elasticsearch.cluster.indices.query_cache.evictions 6714333 1457980502
icebrg.elasticsearch.cluster.indices.completion.size_in_bytes 0 1457980502
icebrg.elasticsearch.cluster.indices.segments.count 18819 1457980502
icebrg.elasticsearch.cluster.indices.segments.memory_in_bytes 244345144361 1457980502
icebrg.elasticsearch.cluster.indices.segments.terms_memory_in_bytes 152179422625 1457980502
icebrg.elasticsearch.cluster.indices.segments.stored_fields_memory_in_bytes 12022503384 1457980502
icebrg.elasticsearch.cluster.indices.segments.term_vectors_memory_in_bytes 0 1457980502
icebrg.elasticsearch.cluster.indices.segments.norms_memory_in_bytes 1201984 1457980502
icebrg.elasticsearch.cluster.indices.segments.doc_values_memory_in_bytes 80142016368 1457980502
icebrg.elasticsearch.cluster.indices.segments.index_writer_memory_in_bytes 2079424 1457980502
icebrg.elasticsearch.cluster.indices.segments.index_writer_max_memory_in_bytes 7681056768 1457980502
icebrg.elasticsearch.cluster.indices.segments.version_map_memory_in_bytes 450 1457980502
icebrg.elasticsearch.cluster.indices.segments.fixed_bit_set_memory_in_bytes 0 1457980502
icebrg.elasticsearch.cluster.indices.percolate.total 0 1457980502
icebrg.elasticsearch.cluster.indices.percolate.time_in_millis 0 1457980502
icebrg.elasticsearch.cluster.indices.percolate.current 0 1457980502
icebrg.elasticsearch.cluster.indices.percolate.memory_size_in_bytes -1 1457980502
icebrg.elasticsearch.cluster.indices.percolate.queries 0 1457980502
icebrg.elasticsearch.cluster.nodes.count.total 12 1457980502
icebrg.elasticsearch.cluster.nodes.count.master_only 0 1457980502
icebrg.elasticsearch.cluster.nodes.count.data_only 9 1457980502
icebrg.elasticsearch.cluster.nodes.count.master_data 3 1457980502
icebrg.elasticsearch.cluster.nodes.count.client 0 1457980502
icebrg.elasticsearch.cluster.nodes.fs.total_in_bytes 95261291888640 1457980502
icebrg.elasticsearch.cluster.nodes.fs.free_in_bytes 40479126708224 1457980502
icebrg.elasticsearch.cluster.nodes.fs.available_in_bytes 35677953056768 1457980502
```
